### PR TITLE
Specfiy version of schema

### DIFF
--- a/tests/py2_nirum.py
+++ b/tests/py2_nirum.py
@@ -309,6 +309,7 @@ class C(object):
 
 class MusicService(Service):
 
+    __nirum_schema_version__ = '0.0.1'
     __nirum_service_methods__ = {
         'get_music_by_artist_name': {
             'artist_name': text_type,

--- a/tests/py3_nirum.py
+++ b/tests/py3_nirum.py
@@ -307,6 +307,7 @@ class C:
 
 class MusicService(Service):
 
+    __nirum_schema_version__ = '0.0.1'
     __nirum_service_methods__ = {
         'get_music_by_artist_name': {
             'artist_name': str,


### PR DESCRIPTION
After spoqa/nirum#112 updated, nirum compiler give a version information to RPC service. so nirum RPC service have to check its server or client has same version with its client or server.

it fixes #60.