### PR TITLE
NameDict should be initialized with dictionary

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -19,6 +19,7 @@ To be released.
   every generated union classes (see also the `pull request`__),
   ``nirum.deserialize.deserialize_union_type()`` function also became to
   lerverage it if present.
+- Fixed ``NameDict`` should be initialized with dictionary.
 
 __ https://github.com/spoqa/nirum/pull/192
 __ https://github.com/spoqa/nirum/pull/192

--- a/nirum/constructs.py
+++ b/nirum/constructs.py
@@ -11,7 +11,7 @@ class NameDict(collections.Mapping):
 
     def __init__(self, names):
         self.facial_names = dict(names)
-        self.behind_names = {b: f for f, b in names}
+        self.behind_names = {b: f for f, b in self.facial_names.items()}
         assert len(names) == len(self.behind_names) == len(self.facial_names)
 
     def __getitem__(self, facial_name):

--- a/tests/constructs_test.py
+++ b/tests/constructs_test.py
@@ -21,3 +21,9 @@ def test_name_dict_assert():
         NameDict([('left', 'x'), ('right', 'x')])
     with raises(AssertionError):
         NameDict([('left', 'x'), ('left', 'y')])
+
+
+def test_name_init_with_dict():
+    nd = NameDict({'foo': 'bar'})
+    assert nd.behind_names == {'bar': 'foo'}
+    assert nd['foo'] == 'bar'


### PR DESCRIPTION
`NameDict.__init__()` has assumption `names` has to be `List[Tuple[str, str]]` type. but it can be initialized with `dict` because `NameDict` implements `typing.Mapping`.