### PR TITLE
Fix pycodestyle dependency problem

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -35,6 +35,7 @@ install_requires = [
     'six', 'iso8601',
 ]
 tests_require = [
+    'pycodestyle < 2.4.0',
     'pytest >= 3.2.3, < 4.0.0',
     'pytest-flake8 >= 0.9.1, < 1.0.0',
     'flake8-import-order >= 0.12, < 1.0',


### PR DESCRIPTION
`flake8` needs `pycodestyle < 2.4.0`, but `setup.py` only declare the version of `flake8`.
Thus, `tox` tries to build with the latest `pycodestyle == 2.4.0` and fails.